### PR TITLE
Fixes 2 bugs in distinct_counties API

### DIFF
--- a/ffp-backend/FPA_FOD_PLUS/views.py
+++ b/ffp-backend/FPA_FOD_PLUS/views.py
@@ -128,7 +128,14 @@ def results(request):
 def distinct_counties_list(request):
     if request.method == 'GET':
         state = request.query_params.get('STATE')
-        counties = Data.objects.filter(STATE=state).values('COUNTY').distinct()
+        fetched_counties = Data.objects.filter(STATE=state).values('COUNTY').distinct()
+        counties = []
+        
+        for row in fetched_counties:
+            if str(row['COUNTY']) != "None":
+                #if str(row['COUNTY']) != "None":
+                counties.append(str(row['COUNTY']))
+        
         serializer = DistinctCountySerializer(counties, context={'request': request}, many=True)
         
         return Response(counties)


### PR DESCRIPTION
The api now does not return null values and instead of returning {'COUNTY' : [county name]} it just returns [county name] Closes issue #154